### PR TITLE
Make bitarray protected

### DIFF
--- a/src/BloomFilter/FilterMemory.cs
+++ b/src/BloomFilter/FilterMemory.cs
@@ -10,7 +10,7 @@ namespace BloomFilter
     /// <seealso cref="BloomFilter.Filter{T}" />
     public class FilterMemory<T> : Filter<T>
     {
-        private readonly BitArray _hashBits;
+        protected readonly BitArray _hashBits;
 
         private readonly object sync = new object();
 


### PR DESCRIPTION
Altering the BitArray to be protected instead of private - allow subclasses access to the current filter state, which would enable functionality to be added without rebuilding (such as importing an existing filter, or exporting the state of the current filter)