### PR TITLE
fix: System.ArgumentOutOfRangeException if number is an exact multiple of MaxInt

### DIFF
--- a/src/BloomFilter/Filter.cs
+++ b/src/BloomFilter/Filter.cs
@@ -245,14 +245,8 @@ public abstract class Filter : IBloomFilter
 
     protected static int LogMaxInt(long number, out int mod)
     {
-        int result = 0;
-        while (number > MaxInt)
-        {
-            number -= MaxInt;
-            result++;
-        }
-        mod = (int)number;
-        return result;
+        mod = (int)(number % MaxInt);
+        return (int)(number / MaxInt);
     }
 
     /// <summary>


### PR DESCRIPTION
I stepped over this issue while testing with really big password files.

A value of an exact multiple of `MaxInt` in parameter `number` of `Filter.LogMaxInt(long number, out int mod)` will yield a return value of `MaxInt` which is outside the index range of `FilterMemory._buckets`. The smallest fix would be to change the loop predicate in `Filter.LogMaxInt(..)` to >= instead >
```c#
    protected static int LogMaxInt(long number, out int mod)
    {
        int result = 0;
        while (number >= MaxInt)
        {
            number -= MaxInt;
            result++;
        }
        mod = (int)number;
        return result;
    }
```

but this can also be reduced to

```c#
    protected static int LogMaxInt(long number, out int mod)
    {
        mod = (int)(number % MaxInt);
        return (int)(number / MaxInt);
    }
```