### PR TITLE
fix: Correct capacity validation to check hashes instead of capacity

### DIFF
--- a/src/BloomFilter/Filter.cs
+++ b/src/BloomFilter/Filter.cs
@@ -89,7 +89,7 @@ public abstract class Filter : IBloomFilter
     {
         if (capacity < 1)
             throw new ArgumentOutOfRangeException("capacity", capacity, "capacity must be > 0");
-        if (capacity < 1)
+        if (hashes < 1)
             throw new ArgumentOutOfRangeException("hashes", hashes, "hashes must be > 0");
 
         Name = name;


### PR DESCRIPTION
A PR to fix this check.

It checks capacity twice while the second should be `hashes`.